### PR TITLE
add support for HTML in data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonresume-theme-engineering",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonresume-theme-engineering",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "description": "JSON Resume theme for engineers",
   "keywords": [
     "jsonresume",

--- a/views/awards.hbs
+++ b/views/awards.hbs
@@ -6,7 +6,7 @@
         <li>
             {{#if title}}
             {{#if summary}}
-            <strong>{{title}}</strong>: {{summary}}
+            <strong>{{title}}</strong>: {{{summary}}}
             {{else}}
             <strong>{{title}}</strong>
             {{/if}}

--- a/views/basics.hbs
+++ b/views/basics.hbs
@@ -18,7 +18,7 @@
     {{#if summary}}
     <div class="summary">
         <h2>Summary</h2>
-        <p>{{summary}}</p>
+        <p>{{{summary}}}</p>
     </div>
     {{/if}}
 </section>

--- a/views/education.hbs
+++ b/views/education.hbs
@@ -22,7 +22,7 @@
     {{#if courses.length}}
     <ul class="courses">
         {{#each courses}}
-        <li>{{.}}</li>
+        <li>{{{.}}}</li>
         {{/each}}
     </ul>
     {{/if}}

--- a/views/volunteer.hbs
+++ b/views/volunteer.hbs
@@ -5,14 +5,14 @@
         {{#> item title=organization subtitle=position location=location startDate=startDate endDate=endDate }}
         {{#if summary}}
         <div class="summary">
-            <p>{{summary}}</p>
+            <p>{{{summary}}}</p>
         </div>
         {{/if}}
 
         {{#if highlights.length}}
         <ul class="highlights">
             {{#each highlights}}
-            <li>{{.}}</li>
+            <li>{{{.}}}</li>
             {{/each}}
         </ul>
         {{/if}}

--- a/views/work.hbs
+++ b/views/work.hbs
@@ -7,7 +7,7 @@
         {{#if highlights.length}}
         <ul class="highlights">
             {{#each highlights}}
-            <li>{{.}}</li>
+            <li>{{{.}}}</li>
             {{/each}}
         </ul>
         {{/if}}


### PR DESCRIPTION
Support HTML tags in certain elements of input data so that minor tweaks to presentation can be encoded there. This is very useful for using lists in summaries, or emphasis in highlights, etc.