### PR TITLE
Give a pdf-compatible max-width and center content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonresume-theme-engineering",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonresume-theme-engineering",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "description": "JSON Resume theme for engineers",
   "keywords": [
     "jsonresume",

--- a/style.css
+++ b/style.css
@@ -2,11 +2,8 @@
 body {
     font-family: Georgia, serif;
     font-size: 11px;
-    margin: 0;
-    padding: 0;
     display: flex;
     justify-content: center;
-    background: #fff;
 }
 
 #resume {

--- a/style.css
+++ b/style.css
@@ -91,7 +91,7 @@ a {
         size: portrait;
         margin: 10mm 25mm;
     }
-    .resume {
+    #resume {
         max-width: 100%;
         border: 0px;
         background: #fff;
@@ -100,7 +100,7 @@ a {
     }
     body,
     html,
-    .resume {
+    #resume {
         margin: 0px;
         padding: 0px;
     }

--- a/style.css
+++ b/style.css
@@ -2,7 +2,18 @@
 body {
     font-family: Georgia, serif;
     font-size: 11px;
-    margin: 24px 48px;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    justify-content: center;
+    background: #fff;
+}
+
+#resume {
+    max-width: 800px;
+    width: 100%;
+    padding: 24px 48px;
+    box-sizing: border-box;
 }
 
 h1 {


### PR DESCRIPTION
this change gives a much nicer experience when hosting the HTML artifact via a webpage.
Otherwise, the CV will stretch—which looks quite ugly on a modern widescreen.